### PR TITLE
fair.py execution path & config.ini loading

### DIFF
--- a/api/evaluator.py
+++ b/api/evaluator.py
@@ -11,13 +11,13 @@ import sys
 import api.utils as ut
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format='\'%(name)s:%(lineno)s\' | %(message)s')
-    
+
 logger = logging.getLogger(os.path.basename(__file__))
 
 
 
 class Evaluator(object):
-    """ A class used to define FAIR indicators tests. It contains all the references to all the tests 
+    """ A class used to define FAIR indicators tests. It contains all the references to all the tests
 
     ...
 
@@ -30,7 +30,7 @@ class Evaluator(object):
     oai_base : str
         Open Archives initiative , This is the place in which the API will ask for the metadata
 
-    lang : Language 
+    lang : Language
     """
 
     def __init__(self, item_id, oai_base=None, lang='en', config=None):
@@ -97,7 +97,7 @@ class Evaluator(object):
         logger.debug("METAdata: %s" % self.metadata)
         global _
         _ = self.translation()
-        
+
     def translation(self):
         # Translations
         t = gettext.translation('messages', 'translations', fallback=True, languages=[self.lang])
@@ -1445,7 +1445,7 @@ class Evaluator(object):
                         if e == self.metadata_schemas[s]:
                             if ut.check_url(e):
                                 points = 100
-                                msg = _("Community schema found: %s" % e) 
+                                msg = _("Community schema found: %s" % e)
         except Exception as e:
             logger.error("Problem loading plugin config: %s" % e)
         try:
@@ -1584,8 +1584,8 @@ class Evaluator(object):
             msg = 'Your (meta)data is not identified by persistent & unique identifiers:'
 
         return (points, msg)
-        
-        
+
+
     def check_standard_license(self, license):
         standard_licenses = ut.licenses_list()
         license_name = None

--- a/api/evaluator.py
+++ b/api/evaluator.py
@@ -1,5 +1,4 @@
 import ast
-import configparser
 import gettext
 import idutils
 import logging
@@ -34,12 +33,13 @@ class Evaluator(object):
     lang : Language 
     """
 
-    def __init__(self, item_id, oai_base=None, lang='en'):
+    def __init__(self, item_id, oai_base=None, lang='en', config=None):
         self.item_id = item_id
         self.oai_base = oai_base
         self.metadata = None
         self.access_protocols = []
         self.cvs = []
+        self.config = config
 
         logger.debug("OAI_BASE IN evaluator: %s" % oai_base)
         if oai_base is not None and oai_base != '' and self.metadata is None:
@@ -75,24 +75,19 @@ class Evaluator(object):
                 self.access_protocols = ['http', 'oai-pmh']
 
         # Config attributes
-        config = configparser.ConfigParser()
-        config_file = 'config.ini'
-        if "CONFIG_FILE" in os.environ:
-            config_file = os.getenv("CONFIG_FILE")
-        config.read(config_file)
         plugin = 'oai-pmh'
         try:
-            self.identifier_term = ast.literal_eval(config[plugin]['identifier_term'])
-            self.terms_quali_generic = ast.literal_eval(config[plugin]['terms_quali_generic'])
-            self.terms_quali_disciplinar = ast.literal_eval(config[plugin]['terms_quali_disciplinar'])
-            self.terms_access = ast.literal_eval(config[plugin]['terms_access'])
-            self.terms_cv = ast.literal_eval(config[plugin]['terms_cv'])
-            self.supported_data_formats = ast.literal_eval(config[plugin]['supported_data_formats'])
-            self.terms_qualified_references = ast.literal_eval(config[plugin]['terms_qualified_references'])
-            self.terms_relations = ast.literal_eval(config[plugin]['terms_relations'])
-            self.terms_license = ast.literal_eval(config[plugin]['terms_license'])
+            self.identifier_term = ast.literal_eval(self.config[plugin]['identifier_term'])
+            self.terms_quali_generic = ast.literal_eval(self.config[plugin]['terms_quali_generic'])
+            self.terms_quali_disciplinar = ast.literal_eval(self.config[plugin]['terms_quali_disciplinar'])
+            self.terms_access = ast.literal_eval(self.config[plugin]['terms_access'])
+            self.terms_cv = ast.literal_eval(self.config[plugin]['terms_cv'])
+            self.supported_data_formats = ast.literal_eval(self.config[plugin]['supported_data_formats'])
+            self.terms_qualified_references = ast.literal_eval(self.config[plugin]['terms_qualified_references'])
+            self.terms_relations = ast.literal_eval(self.config[plugin]['terms_relations'])
+            self.terms_license = ast.literal_eval(self.config[plugin]['terms_license'])
             self.metadata_quality = 100  # Value for metadata quality
-            self.metadata_schemas = ast.literal_eval(config[plugin]['metadata_schemas'])
+            self.metadata_schemas = ast.literal_eval(self.config[plugin]['metadata_schemas'])
         except Exception as e:
             logger.error("Problem loading plugin config: %s" % e)
 

--- a/api/rda.py
+++ b/api/rda.py
@@ -28,7 +28,7 @@ def repo_object(body):
         lang = body.get("lang")
     try:
         if repo == "oai-pmh":
-            eva = Evaluator(item_id, oai_base, lang)
+            eva = Evaluator(item_id, oai_base, lang, config)
         else:
             logger.debug("Trying to import plugin from plugins.%s.plugin" % (repo))
             plugin = importlib.import_module("plugins.%s.plugin" % (repo), ".")

--- a/api/rda.py
+++ b/api/rda.py
@@ -830,14 +830,18 @@ def rda_all(body):
     result_points = 10
     num_of_tests = 10
 
+    from fair import app_dirname
     config = configparser.ConfigParser()
-    config_file = 'config.ini'
     if "CONFIG_FILE" in os.environ:
         config_file = os.getenv("CONFIG_FILE")
     try:
-        config.read_file(config_file)
+        config_file = os.path.join(app_dirname, 'config.ini')
+        config.read_file(open(config_file))
+        logging.debug(
+            'Main configuration successfully loaded: %s' % config_file
+        )
     except configparser.MissingSectionHeaderError as e:
-        message = 'Could not find config file: %s' % config_file
+        message = 'Could not find main config file: %s' % config_file
         logging.error(message)
         logging.debug(e)
         error = {'code': 500, 'message': '%s' % message}
@@ -845,10 +849,14 @@ def rda_all(body):
         return json.dumps(error), 500
 
     generic_config = config['Generic']
-    api_config = generic_config.get('api_config', 'fair-api.yaml')
+    api_config = os.path.join(
+        app_dirname,
+        generic_config.get('api_config', 'fair-api.yaml')
+    )
     try:
         with open(api_config, 'r') as f:
             documents = yaml.full_load(f)
+        logging.debug('API configuration successfully loaded: %s' % api_config)
     except Exception as e:
         message = 'Could not find API config file: %s' % api_config
         logger.error(message)

--- a/api/rda.py
+++ b/api/rda.py
@@ -1,18 +1,18 @@
-import configparser
 import os
 import yaml
 from api.evaluator import Evaluator
 import api.utils as ut
 from connexion import NoContent
+from fair import app_dirname, load_config
 import json
 import importlib
 import logging
 import sys
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format='\'%(name)s:%(lineno)s\' | %(message)s')
-
 logger = logging.getLogger(os.path.basename(__file__))
 
+config = load_config()
 
 
 def repo_object(body):
@@ -829,24 +829,6 @@ def rda_all(body):
     x_principle = ''
     result_points = 10
     num_of_tests = 10
-
-    from fair import app_dirname
-    config = configparser.ConfigParser()
-    if "CONFIG_FILE" in os.environ:
-        config_file = os.getenv("CONFIG_FILE")
-    try:
-        config_file = os.path.join(app_dirname, 'config.ini')
-        config.read_file(open(config_file))
-        logging.debug(
-            'Main configuration successfully loaded: %s' % config_file
-        )
-    except configparser.MissingSectionHeaderError as e:
-        message = 'Could not find main config file: %s' % config_file
-        logging.error(message)
-        logging.debug(e)
-        error = {'code': 500, 'message': '%s' % message}
-        logging.debug('Returning API response: %s' % error)
-        return json.dumps(error), 500
 
     generic_config = config['Generic']
     api_config = os.path.join(

--- a/api/rda.py
+++ b/api/rda.py
@@ -10,7 +10,7 @@ import logging
 import sys
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format='\'%(name)s:%(lineno)s\' | %(message)s')
-    
+
 logger = logging.getLogger(os.path.basename(__file__))
 
 
@@ -776,7 +776,7 @@ def rda_r1_3_02d(body):
                  'test_status': ut.test_status(points),
                  'score': {'earned': points, 'total': 100}}
         return json.dumps(error), 201
-        
+
 def data_01(body):
     eva = repo_object(body)
     try:
@@ -793,7 +793,7 @@ def data_01(body):
                  'test_status': ut.test_status(points),
                  'score': {'earned': points, 'total': 100}}
         return json.dumps(error), 201
-        
+
 def data_02(body):
     eva = repo_object(body)
     try:
@@ -829,20 +829,34 @@ def rda_all(body):
     x_principle = ''
     result_points = 10
     num_of_tests = 10
-    
+
     config = configparser.ConfigParser()
     config_file = 'config.ini'
     if "CONFIG_FILE" in os.environ:
         config_file = os.getenv("CONFIG_FILE")
-    config.read(config_file)
-    api_config = '/FAIR_eva/fair-api.yaml'
     try:
-        if "api_config" in config['Generic']:
-            api_config = config['Generic']['api_config']
+        config.read_file(config_file)
+    except configparser.MissingSectionHeaderError as e:
+        message = 'Could not find config file: %s' % config_file
+        logging.error(message)
+        logging.debug(e)
+        error = {'code': 500, 'message': '%s' % message}
+        logging.debug('Returning API response: %s' % error)
+        return json.dumps(error), 500
+
+    generic_config = config['Generic']
+    api_config = generic_config.get('api_config', 'fair-api.yaml')
+    try:
+        with open(api_config, 'r') as f:
+            documents = yaml.full_load(f)
     except Exception as e:
-        logger.error(e)
-    with open(api_config, 'r') as f:
-        documents = yaml.full_load(f)
+        message = 'Could not find API config file: %s' % api_config
+        logger.error(message)
+        logger.debug(e)
+        error = {'code': 500, 'message': '%s' % message}
+        logger.debug('Returning API response: %s' % error)
+        return json.dumps(error), 500
+
     for e in documents['paths']:
         try:
             if documents['paths'][e]['x-indicator']:

--- a/api/rda.py
+++ b/api/rda.py
@@ -32,8 +32,7 @@ def repo_object(body):
         else:
             logger.debug("Trying to import plugin from plugins.%s.plugin" % (repo))
             plugin = importlib.import_module("plugins.%s.plugin" % (repo), ".")
-            eva = plugin.Plugin(item_id, oai_base, lang)
-
+            eva = plugin.Plugin(item_id, oai_base, lang, config)
     except Exception as e:
         logger.error(e)
         raise Exception(e)

--- a/config.ini.template
+++ b/config.ini.template
@@ -1,5 +1,7 @@
 [Generic]
 doi_url = https://doi.org/
+
+# Relative path to the API config file
 api_config = fair-api.yaml
 
 [local]
@@ -64,7 +66,7 @@ terms_license = [['license', '', '']]
 metadata_schemas = [{'dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/'}]
 
 [digital_csic]
-db_host = 
+db_host =
 db_port =
 oai_ep  =
 

--- a/fair.py
+++ b/fair.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 import logging
 import os
+
 import connexion
 from connexion.resolver import RestyResolver
 import sys
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format='\'%(name)s:%(lineno)s\' | %(message)s')
-    
+
 logger = logging.getLogger(os.path.basename(__file__))
+
+app_dirname = os.path.dirname(os.path.abspath(__file__))
 
 if __name__ == '__main__':
     app = connexion.FlaskApp(__name__)

--- a/fair.py
+++ b/fair.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+
+import configparser
 import logging
 import os
 
@@ -11,6 +13,28 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format='\'%(name)s:%
 logger = logging.getLogger(os.path.basename(__file__))
 
 app_dirname = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_config():
+    config = configparser.ConfigParser()
+    if "CONFIG_FILE" in os.environ:
+        config_file = os.getenv("CONFIG_FILE")
+    try:
+        config_file = os.path.join(app_dirname, 'config.ini')
+        config.read_file(open(config_file))
+        logging.debug(
+            'Main configuration successfully loaded: %s' % config_file
+        )
+    except configparser.MissingSectionHeaderError as e:
+        message = 'Could not find main config file: %s' % config_file
+        logging.error(message)
+        logging.debug(e)
+        error = {'code': 500, 'message': '%s' % message}
+        logging.debug('Returning API response: %s' % error)
+        return json.dumps(error), 500
+
+    return config
+
 
 if __name__ == '__main__':
     app = connexion.FlaskApp(__name__)

--- a/plugins/digital_csic/plugin.py
+++ b/plugins/digital_csic/plugin.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 import ast
-import configparser
 import idutils
 import json
 import logging
@@ -33,7 +32,7 @@ class Digital_CSIC(Evaluator):
     lang : Language
 
     """
-    def __init__(self, item_id, oai_base=None, lang='en'):
+    def __init__(self, item_id, oai_base=None, lang='en', config=None):
         logger.debug("Call parent")
         super().__init__(item_id, oai_base, lang)
         logger.debug("Parent called")
@@ -50,11 +49,7 @@ class Digital_CSIC(Evaluator):
             self.id_type = 'internal'
         oai_metadata = self.metadata
         self.metadata = None
-        config = configparser.ConfigParser()
-        config_file = 'config.ini'
-        logger.debug("Reading plugin config: %s" % os.path.join(os.path.dirname(os.path.realpath(__file__)), config_file))
-        config.read(os.path.join(os.path.dirname(__file__), config_file))
-        logger.debug("CONFIG LOADED")
+        self.config = config
         self.file_list = None
 
         if self.id_type == 'doi' or self.id_type == 'handle':
@@ -72,11 +67,11 @@ class Digital_CSIC(Evaluator):
         #    logger.debug("Trying DB connect")
         #    try:
         #        self.connection = psycopg2.connect(
-        #            user=config['digital_csic']['db_user'],
-        #            password=config['digital_csic']['db_pass'],
-        #            host=config['digital_csic']['db_host'],
-        #            port=config['digital_csic']['db_port'],
-        #            database=config['digital_csic']['db_db'])
+        #            user=self.config['digital_csic']['db_user'],
+        #            password=self.config['digital_csic']['db_pass'],
+        #            host=self.config['digital_csic']['db_host'],
+        #            port=self.config['digital_csic']['db_port'],
+        #            database=self.config['digital_csic']['db_db'])
         #        logger.debug("DB configured")
         #    except Exception as error:
         #        logger.error('Error while fetching data from PostgreSQL ')
@@ -108,23 +103,18 @@ class Digital_CSIC(Evaluator):
             raise Exception(_("Problem accessing data and metadata. Please, try again"))
             #self.metadata = oai_metadata
         logger.debug("Metadata is: %s" % self.metadata)
-        config = configparser.ConfigParser()
-        config_file = 'config.ini'
-        if "CONFIG_FILE" in os.environ:
-            config_file = os.getenv("CONFIG_FILE")
-        config.read(config_file)
         plugin = 'digital_csic'
         try:
-            self.identifier_term = ast.literal_eval(config[plugin]['identifier_term'])
-            self.terms_quali_generic = ast.literal_eval(config[plugin]['terms_quali_generic'])
-            self.terms_quali_disciplinar = ast.literal_eval(config[plugin]['terms_quali_disciplinar'])
-            self.terms_access = ast.literal_eval(config[plugin]['terms_access'])
-            self.terms_cv = ast.literal_eval(config[plugin]['terms_cv'])
-            self.supported_data_formats = ast.literal_eval(config[plugin]['supported_data_formats'])
-            self.terms_qualified_references = ast.literal_eval(config[plugin]['terms_qualified_references'])
-            self.terms_relations = ast.literal_eval(config[plugin]['terms_relations'])
-            self.terms_license = ast.literal_eval(config[plugin]['terms_license'])
-            self.metadata_schemas = ast.literal_eval(config[plugin]['metadata_schemas'])
+            self.identifier_term = ast.literal_eval(self.config[plugin]['identifier_term'])
+            self.terms_quali_generic = ast.literal_eval(self.config[plugin]['terms_quali_generic'])
+            self.terms_quali_disciplinar = ast.literal_eval(self.config[plugin]['terms_quali_disciplinar'])
+            self.terms_access = ast.literal_eval(self.config[plugin]['terms_access'])
+            self.terms_cv = ast.literal_eval(self.config[plugin]['terms_cv'])
+            self.supported_data_formats = ast.literal_eval(self.config[plugin]['supported_data_formats'])
+            self.terms_qualified_references = ast.literal_eval(self.config[plugin]['terms_qualified_references'])
+            self.terms_relations = ast.literal_eval(self.config[plugin]['terms_relations'])
+            self.terms_license = ast.literal_eval(self.config[plugin]['terms_license'])
+            self.metadata_schemas = ast.literal_eval(self.config[plugin]['metadata_schemas'])
             self.metadata_quality = 100  # Value for metadata balancing
         except Exception as e:
             logger.error("Problem loading plugin config: %s" % e)
@@ -771,13 +761,11 @@ class Digital_CSIC(Evaluator):
         return ut.get_handle_str(handle_id)
 
     def metadata_prefix_to_uri(self, prefix):
-        config = configparser.ConfigParser()
-        config_file = 'plugin_config.ini'
-        config.read(os.path.join(os.path.dirname(__file__), config_file))
         plugin = 'digital_csic'
         uri = prefix
         try:
-            metadata_schemas = ast.literal_eval(config[plugin]['metadata_schemas'])
+            logging.debug("TEST A102M: we have this prefix: %s" % prefix)
+            metadata_schemas = ast.literal_eval(self.config[plugin]['metadata_schemas'])
             if prefix in metadata_schemas:
                 uri = metadata_schemas[prefix]
         except Exception as e:

--- a/plugins/dspace7/plugin.py
+++ b/plugins/dspace7/plugin.py
@@ -1028,5 +1028,5 @@ class DSpace_7(Evaluator):
             metadata = pd.DataFrame(data, columns=['metadata_schema', 'element', 'text_value', 'qualifier'])
             return metadata
         except Exception as err:
-            logging.debug('Esception: %s' % err)
+            logging.debug('Exception: %s' % err)
             return None

--- a/plugins/dspace7/plugin.py
+++ b/plugins/dspace7/plugin.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import api.utils as ut
 import ast
-import configparser
 import gettext
 import json
 import logging
@@ -32,7 +31,7 @@ class DSpace_7(Evaluator):
     lang : Language
     """
 
-    def __init__(self, item_id, oai_base=None, lang='en'):
+    def __init__(self, item_id, oai_base=None, lang='en', config=None):
         if oai_base == "":
             oai_base = None
         logger.debug("Call parent")
@@ -47,10 +46,6 @@ class DSpace_7(Evaluator):
         else:
             self.item_id = item_id
             self.id_type = 'internal'
-        config = configparser.ConfigParser()
-        config.read('./config.ini')
-        self.base_url = config['dspace7']['base_url']
-        print('BASE %s' % self.base_url)
         self.internal_id = self.get_internal_id(item_id)
         self.metadata = self.get_item_metadata(self.internal_id)
         self.access_protocol = []
@@ -61,21 +56,22 @@ class DSpace_7(Evaluator):
             self.access_protocols = ['http', 'REST-API']
 
         # Config attributes
-        config = configparser.ConfigParser()
-        config.read('config.ini')
+        self.config = config
+        self.base_url = self.config['dspace7']['base_url']
+        print('BASE %s' % self.base_url)
         plugin = 'dspace7'
         try:
-            self.identifier_term = ast.literal_eval(config[plugin]['identifier_term'])
-            self.terms_quali_generic = ast.literal_eval(config[plugin]['terms_quali_generic'])
-            self.terms_quali_disciplinar = ast.literal_eval(config[plugin]['terms_quali_disciplinar'])
-            self.terms_access = ast.literal_eval(config[plugin]['terms_access'])
-            self.terms_cv = ast.literal_eval(config[plugin]['terms_cv'])
-            self.supported_data_formats = ast.literal_eval(config[plugin]['supported_data_formats'])
-            self.terms_qualified_references = ast.literal_eval(config[plugin]['terms_qualified_references'])
-            self.terms_relations = ast.literal_eval(config[plugin]['terms_relations'])
-            self.terms_license = ast.literal_eval(config[plugin]['terms_license'])
+            self.identifier_term = ast.literal_eval(self.config[plugin]['identifier_term'])
+            self.terms_quali_generic = ast.literal_eval(self.config[plugin]['terms_quali_generic'])
+            self.terms_quali_disciplinar = ast.literal_eval(self.config[plugin]['terms_quali_disciplinar'])
+            self.terms_access = ast.literal_eval(self.config[plugin]['terms_access'])
+            self.terms_cv = ast.literal_eval(self.config[plugin]['terms_cv'])
+            self.supported_data_formats = ast.literal_eval(self.config[plugin]['supported_data_formats'])
+            self.terms_qualified_references = ast.literal_eval(self.config[plugin]['terms_qualified_references'])
+            self.terms_relations = ast.literal_eval(self.config[plugin]['terms_relations'])
+            self.terms_license = ast.literal_eval(self.config[plugin]['terms_license'])
             self.metadata_quality = 100  # Value for metadata quality
-            self.metadata_schemas = ast.literal_eval(config[plugin]['metadata_schemas'])
+            self.metadata_schemas = ast.literal_eval(self.config[plugin]['metadata_schemas'])
         except Exception as e:
             logger.error("Problem loading plugin config: %s" % e)
         

--- a/plugins/dspace7/plugin.py
+++ b/plugins/dspace7/plugin.py
@@ -50,7 +50,7 @@ class DSpace_7(Evaluator):
         self.metadata = self.get_item_metadata(self.internal_id)
         self.access_protocol = []
         self.oai_base = oai_base
-        print('INTERNAL ID: %s ITEM ID: %s' % (self.internal_id,
+        logging.debug('INTERNAL ID: %s ITEM ID: %s' % (self.internal_id,
                                                self.item_id))
         if len(self.metadata) > 0:
             self.access_protocols = ['http', 'REST-API']
@@ -58,7 +58,7 @@ class DSpace_7(Evaluator):
         # Config attributes
         self.config = config
         self.base_url = self.config['dspace7']['base_url']
-        print('BASE %s' % self.base_url)
+        logging.debug('BASE %s' % self.base_url)
         plugin = 'dspace7'
         try:
             self.identifier_term = ast.literal_eval(self.config[plugin]['identifier_term'])
@@ -125,11 +125,11 @@ class DSpace_7(Evaluator):
             url = self.base_url + 'api/core/bundles/%s/bitstreams' \
                 % e['uuid']
             resp_file = requests.get(url)
-            print(url)
+            logging.debug(url)
             files = json.loads(resp_file.content)
-            print(files)
+            logging.debug(files)
             for e_b in files['_embedded']['bitstreams']:
-                print('Bitstream ID: %s | Name: %s' % (e_b['uuid'],
+                logging.debug('Bitstream ID: %s | Name: %s' % (e_b['uuid'],
                                                        e_b['name']))
                 name_files = name_files + ' ' + e_b['name']
                 num_files = num_files + 1
@@ -360,7 +360,7 @@ class DSpace_7(Evaluator):
             resp_file = requests.get(url)
             files = json.loads(resp_file.content)
             for e_b in files['_embedded']['bitstreams']:
-                print('Bitstream ID: %s | Name: %s' % (e_b['uuid'],
+                logging.debug('Bitstream ID: %s | Name: %s' % (e_b['uuid'],
                                                        e_b['name']))
                 name_files = name_files + ' ' + e_b['name']
                 num_files = num_files + 1
@@ -616,7 +616,7 @@ class DSpace_7(Evaluator):
                 elif ut.check_doi(self.metadata[elem][0]['value']):
                     dois = dois + 1
         except Exception as err:
-            print('Exception: %s' % err)
+            logging.debug('Exception: %s' % err)
 
         if orcids > 0 or pids > 0 or dois > 0:
             points = 100
@@ -998,13 +998,13 @@ class DSpace_7(Evaluator):
         internal_id = item_id
         resp = requests.get(self.base_url + 'api/pid/find?id=%s'
                             % item_id)
-        print(resp)
+        logging.debug(resp)
         try:
             item = json.loads(resp.content)
             internal_id = item['id']
         except Exception as err:
 
-            print('Exception: %s' % err)
+            logging.debug('Exception: %s' % err)
             return internal_id
 
         # print("Internal ID: %s" % internal_id)
@@ -1028,5 +1028,5 @@ class DSpace_7(Evaluator):
             metadata = pd.DataFrame(data, columns=['metadata_schema', 'element', 'text_value', 'qualifier'])
             return metadata
         except Exception as err:
-            print('Esception: %s' % err)
+            logging.debug('Esception: %s' % err)
             return None

--- a/plugins/gbif/plugin.py
+++ b/plugins/gbif/plugin.py
@@ -79,14 +79,14 @@ class Plugin(Evaluator):
         url = idutils.to_url(self.item_id, idutils.detect_identifier_schemes(self.item_id)[0], url_scheme='http')
         response = requests.get(url, verify=False, allow_redirects=True)
         if response.history:
-            print("Request was redirected")
+            logging.debug("Request was redirected")
             for resp in response.history:
-                print(resp.status_code, resp.url)
-            print("Final destination:")
-            print(response.status_code, response.url)
+                logging.debug(resp.status_code, resp.url)
+            logging.debug("Final destination:")
+            logging.debug(response.status_code, response.url)
             final_url = response.url
         else:
-            print("Request was not redirected")
+            logging.debug("Request was not redirected")
 
         final_url = final_url.replace("/resource?", "/eml.do?")
         response = requests.get(final_url, verify=False)

--- a/plugins/gbif/plugin.py
+++ b/plugins/gbif/plugin.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 import ast
-import configparser
 import idutils
 import logging
 import os
@@ -12,7 +11,7 @@ import sys
 import xml.etree.ElementTree as ET
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG, format='\'%(name)s:%(lineno)s\' | %(message)s')
-    
+
 logger = logging.getLogger(os.path.basename(__file__))
 
 
@@ -39,8 +38,7 @@ class Plugin(Evaluator):
     says(sound=None)
         Prints the animals name and what sound it makes
     """
-
-    def __init__(self, item_id, oai_base=None, lang='en'):
+    def __init__(self, item_id, oai_base=None, lang='en', config=None):
         logger.debug("Creating GBIF")
         super().__init__(item_id, oai_base, lang)
         # TO REDEFINE - WHICH IS YOUR PID TYPE?
@@ -49,12 +47,7 @@ class Plugin(Evaluator):
         global _
         _ = super().translation()
 
-        config = configparser.ConfigParser()
-        config_file = 'config.ini'
-        if "CONFIG_FILE" in os.environ:
-            config_file = os.getenv("CONFIG_FILE")
-        config.read(config_file)
-        logger.debug("CONFIG LOADED")
+        self.config = config
 
         # You need a way to get your metadata in a similar format
         metadata_sample = self.get_metadata()
@@ -70,24 +63,15 @@ class Plugin(Evaluator):
 
         # Config attributes
         plugin = 'gbif'
-        config = configparser.ConfigParser()
-        config_file = "%s/plugins/%s/config.ini" % (os.getcwd(), plugin)
-        if "CONFIG_FILE" in os.environ:
-            config_file = os.getenv("CONFIG_FILE")
-        logger.debug("Config file to load: %s" % config_file)
-        config.read(config_file)
-
-        self.identifier_term = ast.literal_eval(config[plugin]['identifier_term'])
-        self.terms_quali_generic = ast.literal_eval(config[plugin]['terms_quali_generic'])
-        self.terms_quali_disciplinar = ast.literal_eval(config[plugin]['terms_quali_disciplinar'])
-        self.terms_access = ast.literal_eval(config[plugin]['terms_access'])
-        self.terms_cv = ast.literal_eval(config[plugin]['terms_cv'])
-        self.supported_data_formats = ast.literal_eval(config[plugin]['supported_data_formats'])
-        self.terms_qualified_references = ast.literal_eval(config[plugin]['terms_qualified_references'])
-        self.terms_relations = ast.literal_eval(config[plugin]['terms_relations'])
-        self.terms_license = ast.literal_eval(config[plugin]['terms_license'])
-        self.metadata_schemas = ast.literal_eval(config[plugin]['metadata_schemas'])
-        self.metadata_quality = 100  # Value for metadata balancing
+        self.identifier_term = self.config[plugin]['identifier_term']
+        self.terms_quali_generic = ast.literal_eval(self.config[plugin]['terms_quali_generic'])
+        self.terms_quali_disciplinar = ast.literal_eval(self.config[plugin]['terms_quali_disciplinar'])
+        self.terms_access = ast.literal_eval(self.config[plugin]['terms_access'])
+        self.terms_cv = ast.literal_eval(self.config[plugin]['terms_cv'])
+        self.supported_data_formats = ast.literal_eval(self.config[plugin]['supported_data_formats'])
+        self.terms_qualified_references = ast.literal_eval(self.config[plugin]['terms_qualified_references'])
+        self.terms_relations = ast.literal_eval(self.config[plugin]['terms_relations'])
+        self.terms_license = ast.literal_eval(self.config[plugin]['terms_license'])
 
     # TO REDEFINE - HOW YOU ACCESS METADATA?
 


### PR DESCRIPTION
Be able to start FAIR_eva API regardless of the current path where the file (`fair.py`) is placed. 

Other related change covered by this PR is a fix to avoid reloading the configuration files more than once within the plugin code (fixes #51)