### PR TITLE
Changed wrong variable name

### DIFF
--- a/plugins/epos/plugin.py
+++ b/plugins/epos/plugin.py
@@ -1029,7 +1029,7 @@ class Plugin(Evaluator):
             )
         else:
             msg = "Could not fing any metadata element that enhance reusability"
-        points = len(element_list) / len(terms_reusability_richness) * 100
+        points = len(reusability_element_list) / len(terms_reusability_richness) * 100
 
         return (points, [{"message": msg, "points": points}])
 


### PR DESCRIPTION
In function r1_01m there was a wrong variable name that caused the function to crash