### PR TITLE
Method to format output as a PrettyTable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ reportlab
 PyPDF2
 rdflib
 dicttoxml
+prettytable

--- a/scripts/fair-eva.py
+++ b/scripts/fair-eva.py
@@ -171,10 +171,14 @@ def print_table(result_json):
                 indicator_count += 1
                 if indicator_count == indicator_total:
                     has_divider = True
+                # Truncate points to two decimals
+                points = indicator_result["points"]
+                if isinstance(points, float):
+                    points = "%.2f" % points
                 table.add_row(
                     [
                         indicator_result["name"].upper(),
-                        indicator_result["points"],
+                        points,
                         output_message,
                     ],
                     divider=has_divider,

--- a/scripts/fair-eva.py
+++ b/scripts/fair-eva.py
@@ -151,6 +151,8 @@ def print_table(result_json):
     for identifier, fair_results in result_json.items():
         table = PrettyTable()
         table.field_names = ["FAIR indicator", "Score", "Output"]
+        table.align = "l"
+        table._max_width = {"Output": 100}
 
         # Split by principle: required for setting dividers in the resultant table
         indicators_by_principle = {}

--- a/scripts/fair-eva.py
+++ b/scripts/fair-eva.py
@@ -52,7 +52,6 @@ def get_input_args():
         type=str,
         help="(meta)data repository endpoint",
     )
-    parser.add_argument("-s", "--scores", action="store_true")
     parser.add_argument(
         "--api-endpoint",
         metavar="URL",
@@ -63,7 +62,6 @@ def get_input_args():
             "http://localhost:9090/v1.0/rda/rda_all"
         ),
     )
-    parser.add_argument("-fs", "--full-scores", action="store_true")
     parser.add_argument("-j", "--json", action="store_true")
     parser.add_argument("--totals", action="store_true")
 

--- a/scripts/fair-eva.py
+++ b/scripts/fair-eva.py
@@ -144,8 +144,7 @@ def format_msg_for_table(message_data):
                     )
                     # print(output_message)
                 elif len(message_data) == 1:
-                    print(message_data[0].get("message", "Not available"))
-                    # output_message = message_data[0].get("message", "Not available")
+                    output_message = message_data[0].get("message", "Not available")
     return output_message
 
 

--- a/scripts/fair-eva.py
+++ b/scripts/fair-eva.py
@@ -124,6 +124,64 @@ def printpoints(
         print("In " + str(key) + " your item has " + str(points[key]) + " points")
 
 
+def format_msg_for_table(message_data):
+    output_message = "Not available"
+    # FIXME Check to overcome issue: https://github.com/EOSC-synergy/FAIR_eva/issues/188
+    if isinstance(message_data, str):
+        output_message = message_data
+    else:
+        if len(message_data) > 0:
+            # FIXME Overcome same issue as above: https://github.com/EOSC-synergy/FAIR_eva/issues/188
+            if isinstance(message_data[0], str):
+                output_message = "\n".join(message_data)
+            else:
+                if len(message_data) > 1:
+                    output_message = "\n".join(
+                        [
+                            "%s (points: %s)" % (item["message"], item["points"])
+                            for item in message_data
+                        ]
+                    )
+                    # print(output_message)
+                elif len(message_data) == 1:
+                    print(message_data[0].get("message", "Not available"))
+                    # output_message = message_data[0].get("message", "Not available")
+    return output_message
+
+
+def print_table(result_json):
+    for identifier, fair_results in result_json.items():
+        table = PrettyTable()
+        table.field_names = ["FAIR indicator", "Score", "Output"]
+
+        # Split by principle: required for setting dividers in the resultant table
+        indicators_by_principle = {}
+        for principle, principle_result in fair_results.items():
+            indicators_by_principle[principle] = list(principle_result.values())
+
+        for principle, indicator_list in indicators_by_principle.items():
+            print(principle)
+            indicator_total = len(indicator_list)
+            indicator_count = 0
+            for indicator_result in indicator_list:
+                # Format output message
+                output_message = format_msg_for_table(indicator_result.get("msg", []))
+                # Set divider
+                has_divider = False
+                indicator_count += 1
+                if indicator_count == indicator_total:
+                    has_divider = True
+                table.add_row(
+                    [
+                        indicator_result["name"].upper(),
+                        indicator_result["points"],
+                        output_message,
+                    ],
+                    divider=has_divider,
+                )
+        print(table)
+
+
 def main():
     logging.basicConfig(level=logging.INFO)
 

--- a/scripts/fair-eva.py
+++ b/scripts/fair-eva.py
@@ -28,6 +28,7 @@ import socket
 import sys
 import time
 from flask_babel import Babel, gettext, lazy_gettext as _l
+from prettytable import PrettyTable
 
 
 def get_input_args():

--- a/scripts/fair-eva.py
+++ b/scripts/fair-eva.py
@@ -142,7 +142,6 @@ def format_msg_for_table(message_data):
                             for item in message_data
                         ]
                     )
-                    # print(output_message)
                 elif len(message_data) == 1:
                     output_message = message_data[0].get("message", "Not available")
     return output_message
@@ -159,7 +158,6 @@ def print_table(result_json):
             indicators_by_principle[principle] = list(principle_result.values())
 
         for principle, indicator_list in indicators_by_principle.items():
-            print(principle)
             indicator_total = len(indicator_list)
             indicator_count = 0
             for indicator_result in indicator_list:


### PR DESCRIPTION
Formats the output of `scripts/fair-eva.py` as a PrettyTable. It is now the default behaviour and supersedes the option `--full-scores`. The option `--scores` has been also changed to `--totals` and formatted as a table as well.