### PR TITLE
Fix: gather 'start_date' and 'end_date' as part of temporal coverage …

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -891,7 +891,9 @@ def check_link(address, return_http_code=False):
     resolves = False
     req = urllib.request.Request(url=address)
     try:
-        resp = urllib.request.urlopen(req)
+        resp = urllib.request.urlopen(req, timeout=15)
+    except urllib.error.URLError as e:
+        logging.warning("Timeout reached while trying to connect to '%s'" % address)
     except urllib.error.HTTPError as e:
         logging.warning("Could not access to resource: %s" % address)
     else:

--- a/api/utils.py
+++ b/api/utils.py
@@ -888,14 +888,20 @@ def resolve_handle(handle_id):
 
 
 def check_link(address, return_http_code=False):
+    resolves = False
     req = urllib.request.Request(url=address)
-    resp = urllib.request.urlopen(req)
-    if return_http_code:
-        return resp.status
-    if resp.status in [400, 404, 403, 408, 409, 501, 502, 503]:
-        return False
+    try:
+        resp = urllib.request.urlopen(req)
+    except urllib.error.HTTPError as e:
+        logging.warning("Could not access to resource: %s" % address)
     else:
-        return True
+        http_code = resp.status
+        logging.debug("Returned HTTP status from '%s': %s" % (address, http_code))
+        if return_http_code:
+            return http_code
+        if http_code not in ["400", "404", "403", "408", "409", "501", "502", "503"]:
+            resolves = True
+    return resolves
 
 
 def get_protocol_scheme(url):

--- a/plugins/epos/plugin.py
+++ b/plugins/epos/plugin.py
@@ -83,6 +83,7 @@ class MetadataValues(MetadataValuesBase):
                 "start_date": value_data.get("startDate", ""),
                 "end_date": value_data.get("endDate", ""),
             }
+            for value_data in element_values
         ]
 
     @classmethod

--- a/plugins/epos/plugin.py
+++ b/plugins/epos/plugin.py
@@ -827,17 +827,22 @@ class Plugin(Evaluator):
         for uri in data_access_uri:
             resolves = False
             schemes = idutils.detect_identifier_schemes(uri)
-            logger.debug("Identifier schemes found: %s" % schemes)
-            if "doi" in schemes or "handle" in schemes:
-                resolves = ut.resolve_handle(uri)[0]
-            elif "url" in schemes:
-                resolves = ut.check_link(uri)
+            if not schemes:
+                logger.warning("Could not get the scheme/s from the value: %s" % uri)
             else:
-                logger.warning(
-                    "Scheme/s used by the identifier not known: %s" % schemes
+                logger.debug(
+                    "Identifier schemes found for the value '%s': %s" % (uri, schemes)
                 )
-            if resolves:
-                resolvable_uris.append(uri)
+                if "doi" in schemes or "handle" in schemes:
+                    resolves = ut.resolve_handle(uri)[0]
+                elif "url" in schemes:
+                    resolves = ut.check_link(uri)
+                else:
+                    logger.warning(
+                        "Scheme/s used by the identifier not known: %s" % schemes
+                    )
+                if resolves:
+                    resolvable_uris.append(uri)
 
         resolvable_uris_num = len(resolvable_uris)
         if resolvable_uris:


### PR DESCRIPTION
Handle exceptions when accessing external URLs 